### PR TITLE
fix!: improve nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -385,3 +385,6 @@ svg-inkscape/
 .xamples
 algotex-ctan.zip
 algotex.tds.zip
+
+# nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,36 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697915759,
-        "narHash": "sha256-WyMj5jGcecD+KC8gEs+wFth1J1wjisZf8kVZH13f1Zo=",
-        "owner": "NixOS",
+        "lastModified": 1740916017,
+        "narHash": "sha256-Ze/3XCElkVljFCnBKezLldOz2ZaGp7eozxRqFzACnMI=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "51d906d2341c9e866e48c2efcaac0f2d70bfd43e",
+        "rev": "b58e19b11fe72175fd7a9e014a4786a91e99da5f",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "tuda-logo": "tuda-logo"
+      }
+    },
+    "tuda-logo": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-F/1F1yQbDhyXKXqeWZFFVB/tLWoSuVSbEgFolQrrSoM=",
+        "type": "file",
+        "url": "https://upload.wikimedia.org/wikipedia/de/2/24/TU_Darmstadt_Logo.svg"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://upload.wikimedia.org/wikipedia/de/2/24/TU_Darmstadt_Logo.svg"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740916017,
-        "narHash": "sha256-Ze/3XCElkVljFCnBKezLldOz2ZaGp7eozxRqFzACnMI=",
+        "lastModified": 1743259260,
+        "narHash": "sha256-ArWLUgRm1tKHiqlhnymyVqi5kLNCK5ghvm06mfCl4QY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b58e19b11fe72175fd7a9e014a4786a91e99da5f",
+        "rev": "eb0e0f21f15c559d2ac7633dc81d079d1caf5f5f",
         "type": "github"
       },
       "original": {
@@ -19,19 +19,19 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "tuda-logo": "tuda-logo"
+        "tuda-pdf": "tuda-pdf"
       }
     },
-    "tuda-logo": {
+    "tuda-pdf": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-F/1F1yQbDhyXKXqeWZFFVB/tLWoSuVSbEgFolQrrSoM=",
+        "narHash": "sha256-ThoKm1Tg818VJ/Hx6gWGMWqwg9puoUxL7mvLJhMyDvU=",
         "type": "file",
-        "url": "https://upload.wikimedia.org/wikipedia/de/2/24/TU_Darmstadt_Logo.svg"
+        "url": "https://www.tu-darmstadt.de/media/medien_stabsstelle_km/services/medien_cd/das_bild_der_tu_darmstadt.pdf"
       },
       "original": {
         "type": "file",
-        "url": "https://upload.wikimedia.org/wikipedia/de/2/24/TU_Darmstadt_Logo.svg"
+        "url": "https://www.tu-darmstadt.de/media/medien_stabsstelle_km/services/medien_cd/das_bild_der_tu_darmstadt.pdf"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743259260,
-        "narHash": "sha256-ArWLUgRm1tKHiqlhnymyVqi5kLNCK5ghvm06mfCl4QY=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb0e0f21f15c559d2ac7633dc81d079d1caf5f5f",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -25,7 +25,7 @@
     "tuda-pdf": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-ThoKm1Tg818VJ/Hx6gWGMWqwg9puoUxL7mvLJhMyDvU=",
+        "narHash": "sha256-CCOWBx10m9fRBLbpEuqAAf7AGLo01p1LEU5fOWyqwdQ=",
         "type": "file",
         "url": "https://www.tu-darmstadt.de/media/medien_stabsstelle_km/services/medien_cd/das_bild_der_tu_darmstadt.pdf"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -22,17 +22,12 @@
     {
       # shell for using algotex
       devShells.${system}.default = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          python311Packages.pygments
-          pre-commit
-          python310Packages.editorconfig
-
+        buildInputs = [
+          pkgs.python313Packages.pygments
           self.packages.${system}.latex_with_algotex
         ];
-        shellHook = ''
-          pre-commit install
-        '';
       };
+
       packages.${system} = {
         algotex = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
           name = "algotex";

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,8 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
-    tuda-logo = {
-      url = "https://upload.wikimedia.org/wikipedia/de/2/24/TU_Darmstadt_Logo.svg";
+    tuda-pdf = {
+      url = "https://www.tu-darmstadt.de/media/medien_stabsstelle_km/services/medien_cd/das_bild_der_tu_darmstadt.pdf";
       flake = false;
     };
   };
@@ -13,7 +13,7 @@
     {
       self,
       nixpkgs,
-      tuda-logo,
+      tuda-pdf,
     }:
     let
       system = "x86_64-linux";
@@ -38,7 +38,10 @@
             tlType = "run";
             tlDeps = with pkgs.texlive; [ latex ];
           };
-          nativeBuildInputs = with pkgs; [ librsvg ];
+          nativeBuildInputs = with pkgs; [
+            inkscape
+            librsvg
+          ];
           installPhase = ''
             runHook preInstall
 
@@ -50,7 +53,13 @@
             # build tuda logo
             logo_path=$out/tex/latex/local
             mkdir -p $logo_path
-            rsvg-convert -f pdf -o $logo_path/tuda_logo.pdf ${tuda-logo}
+            cp ${tuda-pdf} tuda.pdf
+
+            # see https://github.com/tudalgo/AlgoTeX/blob/5de6300bcbbf4ffb5c6ec9e8fb29fdd2f3b7896b/Dockerfile.logo
+            inkscape tuda.pdf --export-filename=p1_i.svg --export-dpi=3000 --pages=1
+            sed -i 's/icc-color([^)]*)//g' p1_i.svg
+            sed -i 's/#000000/#1d1d1bff/g' p1_i.svg
+            rsvg-convert -f pdf -o $logo_path/tuda_logo.pdf p1_i.svg --export-id=g23
 
             runHook postInstall
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       pkgs = import nixpkgs { inherit system; };
     in
     {
-      # shell for using algotex
+      # minimal example shell for using algotex
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = [
           pkgs.python313Packages.pygments
@@ -29,6 +29,7 @@
       };
 
       packages.${system} = {
+        # algotex and logo only
         algotex = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
           name = "algotex";
           src = ./.;
@@ -41,10 +42,12 @@
           installPhase = ''
             runHook preInstall
 
+            # copy algotex files
             algotex_path=$out/tex/latex/algotex
             mkdir -p $algotex_path
             cp $src/tex/* $algotex_path/
 
+            # build tuda logo
             logo_path=$out/tex/latex/local
             mkdir -p $logo_path
             rsvg-convert -f pdf -o $logo_path/tuda_logo.pdf ${tuda-logo}
@@ -55,6 +58,7 @@
           dontBuild = true;
         });
 
+        # full texlive distribution with algotex and the logo file
         latex_with_algotex = pkgs.texlive.combine {
           inherit (pkgs.texlive) scheme-full;
           inherit (self.packages.${system}) algotex;

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
               mkdir -p $logo_path
               cp ${tuda-pdf} tuda.pdf
 
-              # see https://github.com/tudalgo/AlgoTeX/blob/5de6300bcbbf4ffb5c6ec9e8fb29fdd2f3b7896b/Dockerfile.logo
+              # see https://github.com/tudalgo/AlgoTeX/commit/ce0e2c032d3067070ef07bd8c84520f8209e1997
               inkscape tuda.pdf --export-filename=p1_i.svg --export-dpi=3000 --pages=1
               sed -i 's/icc-color([^)]*)//g' p1_i.svg
               sed -i 's/#000000/#1d1d1bff/g' p1_i.svg

--- a/flake.nix
+++ b/flake.nix
@@ -16,82 +16,64 @@
       tuda-pdf,
     }:
     let
-      systems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "x86_64-linux"
-      ];
-      forAllSystems = nixpkgs.lib.genAttrs systems;
-      allPkgs = forAllSystems (system: import nixpkgs { inherit system; });
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
     in
     {
       # minimal example shell for using algotex
-      devShells = forAllSystems (
-        system:
-        let
-          inherit (allPkgs.${system}) pkgs;
-        in
-        pkgs.mkShell {
-          buildInputs = [
-            pkgs.python313Packages.pygments
-            self.packages.${system}.latex_with_algotex
-          ];
-        }
-      );
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          pkgs.python313Packages.pygments
+          self.packages.${system}.latex_with_algotex
+        ];
+      };
 
-      packages = forAllSystems (
-        system:
-        let
-          inherit (allPkgs.${system}) pkgs;
-        in
-        {
-          # algotex and logo only
-          algotex = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
-            name = "algotex";
-            src = ./.;
-            passthru = {
-              pkgs = [ finalAttrs.finalPackage ];
-              tlType = "run";
-              tlDeps = with pkgs.texlive; [ latex ];
-            };
-            nativeBuildInputs = with pkgs; [
-              inkscape
-              librsvg
-            ];
-            installPhase = ''
-              runHook preInstall
-
-              # copy algotex files
-              algotex_path=$out/tex/latex/algotex
-              mkdir -p $algotex_path
-              cp $src/tex/* $algotex_path/
-
-              # build tuda logo
-              logo_path=$out/tex/latex/local
-              mkdir -p $logo_path
-              cp ${tuda-pdf} tuda.pdf
-
-              # see https://github.com/tudalgo/AlgoTeX/commit/ce0e2c032d3067070ef07bd8c84520f8209e1997
-              inkscape tuda.pdf --export-filename=p1_i.svg --export-dpi=3000 --pages=1
-              sed -i 's/icc-color([^)]*)//g' p1_i.svg
-              sed -i 's/#000000/#1d1d1bff/g' p1_i.svg
-              rsvg-convert -f pdf -o $logo_path/tuda_logo.pdf p1_i.svg --export-id=g20
-
-              runHook postInstall
-            '';
-            dontConfigure = true;
-            dontBuild = true;
-          });
-
-          # full texlive distribution with algotex and the logo file
-          latex_with_algotex = pkgs.texlive.combine {
-            inherit (pkgs.texlive) scheme-full;
-            inherit (self.packages.${system}) algotex;
+      packages.${system} = {
+        # algotex and logo only
+        algotex = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+          name = "algotex";
+          src = ./.;
+          passthru = {
+            pkgs = [ finalAttrs.finalPackage ];
+            tlType = "run";
+            tlDeps = with pkgs.texlive; [ latex ];
           };
+          nativeBuildInputs = with pkgs; [
+            inkscape
+            librsvg
+          ];
+          installPhase = ''
+            runHook preInstall
 
-          default = self.packages.${system}.latex_with_algotex;
-        }
-      );
+            # copy algotex files
+            algotex_path=$out/tex/latex/algotex
+            mkdir -p $algotex_path
+            cp $src/tex/* $algotex_path/
+
+            # build tuda logo
+            logo_path=$out/tex/latex/local
+            mkdir -p $logo_path
+            cp ${tuda-pdf} tuda.pdf
+
+            # see https://github.com/tudalgo/AlgoTeX/commit/ce0e2c032d3067070ef07bd8c84520f8209e1997
+            inkscape tuda.pdf --export-filename=p1_i.svg --export-dpi=3000 --pages=1
+            sed -i 's/icc-color([^)]*)//g' p1_i.svg
+            sed -i 's/#000000/#1d1d1bff/g' p1_i.svg
+            rsvg-convert -f pdf -o $logo_path/tuda_logo.pdf p1_i.svg --export-id=g20
+
+            runHook postInstall
+          '';
+          dontConfigure = true;
+          dontBuild = true;
+        });
+
+        # full texlive distribution with algotex and the logo file
+        latex_with_algotex = pkgs.texlive.combine {
+          inherit (pkgs.texlive) scheme-full;
+          inherit (self.packages.${system}) algotex;
+        };
+
+        default = self.packages.${system}.latex_with_algotex;
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
               inkscape tuda.pdf --export-filename=p1_i.svg --export-dpi=3000 --pages=1
               sed -i 's/icc-color([^)]*)//g' p1_i.svg
               sed -i 's/#000000/#1d1d1bff/g' p1_i.svg
-              rsvg-convert -f pdf -o $logo_path/tuda_logo.pdf p1_i.svg --export-id=g23
+              rsvg-convert -f pdf -o $logo_path/tuda_logo.pdf p1_i.svg --export-id=g20
 
               runHook postInstall
             '';


### PR DESCRIPTION
rewrite because i had to see my horrible old code thank to @alexstaeding
<sup>what was i cooking :skull:</sup>
- **breaking changes: outputs renamed, inputs changed, algotex breaking changes**
- inputs: directly reference nixpkgs and the tuda-logo
- gitignore: add entry for result smylink
- devshell: drop pre-commit, this is just a minimal example shell
- outputs:
  - `algotex`:
    - expose as output for consumers
    - don't use a fixed commit
    - general improvements
  - `patched-latex`: rename to `latex_with_algotex` to better reflect what it is

due to time constraints, i only did basic testing (building the example file using the devshell), @alexstaeding please test this flake with the exhaustiveness you deem necessary

further considerations:
- potentially support more systems (maybe using the [nix-systems](https://github.com/nix-systems/nix-systems) pattern, though i'm still undecided on whether i like it or not)
- we could expose the logo as an output as well