### PR TITLE
Snippet for javadoc description

### DIFF
--- a/tex/snippets.def
+++ b/tex/snippets.def
@@ -177,3 +177,4 @@
         können Sie sich bei der Umsetzung an den Beispielen aus den oben genannten Kapiteln orientieren.
     \end{grayInfoBox}
 }
+

--- a/tex/snippets.def
+++ b/tex/snippets.def
@@ -178,3 +178,12 @@
     \end{grayInfoBox}
 }
 
+\DeclareSnippet{javadoc-hinweise}{Hinweise zur Vorlage}{
+    \begin{infoBox}
+        \fatsf{Hinweise Vorlage:}
+        \medskip\\
+        Ab dieser Übung werden die vorgegebenen Klassen, Attribute, Konstruktoren und Methoden nicht mehr im Detail beschrieben.
+        Bitte entnehmen Sie alle weiteren Informationen den Javadocs der Vorlage.
+        Eigenständig zu implementierende Konstrukte sind weiterhin im Übungsblatt erläutert.
+    \end{infoBox}
+}


### PR DESCRIPTION
To reduce the amount of text in the exercise sheets, detailed method descriptions are now moved into the Javadoc comments in the code. The TeX/Pages file only contains the task formulation and a short reference to the Javadoc.

This PR adds a snippet with a hint note explaining this approach.